### PR TITLE
Feature/server write multiple

### DIFF
--- a/rodbus/examples/perf.rs
+++ b/rodbus/examples/perf.rs
@@ -15,26 +15,6 @@ impl ServerHandler for Handler {
     fn read_coils(&mut self, range: AddressRange) -> Result<&[bool], ExceptionCode> {
         Self::get_range_of(self.coils.as_ref(), range)
     }
-
-    fn read_discrete_inputs(&mut self, _: AddressRange) -> Result<&[bool], ExceptionCode> {
-        Err(ExceptionCode::IllegalFunction)
-    }
-
-    fn read_holding_registers(&mut self, _: AddressRange) -> Result<&[u16], ExceptionCode> {
-        Err(ExceptionCode::IllegalFunction)
-    }
-
-    fn read_input_registers(&mut self, _: AddressRange) -> Result<&[u16], ExceptionCode> {
-        Err(ExceptionCode::IllegalFunction)
-    }
-
-    fn write_single_coil(&mut self, _: Indexed<bool>) -> Result<(), ExceptionCode> {
-        Err(ExceptionCode::IllegalFunction)
-    }
-
-    fn write_single_register(&mut self, _: Indexed<u16>) -> Result<(), ExceptionCode> {
-        Err(ExceptionCode::IllegalFunction)
-    }
 }
 
 #[tokio::main(threaded_scheduler)]

--- a/rodbus/examples/server.rs
+++ b/rodbus/examples/server.rs
@@ -52,21 +52,37 @@ impl ServerHandler for SimpleHandler {
     }
 
     fn write_single_coil(&mut self, value: Indexed<bool>) -> Result<(), ExceptionCode> {
-        log::info!("write single coil, index: {} value: {}", value.index, value. value);
+        log::info!(
+            "write single coil, index: {} value: {}",
+            value.index,
+            value.value
+        );
         Ok(())
     }
 
     fn write_single_register(&mut self, value: Indexed<u16>) -> Result<(), ExceptionCode> {
-        log::info!("write single register, index: {} value: {}", value.index, value.value);
+        log::info!(
+            "write single register, index: {} value: {}",
+            value.index,
+            value.value
+        );
         Ok(())
     }
 
-    fn write_multiple_coils(&mut self, range: AddressRange, _iter: &BitIterator) -> Result<(), ExceptionCode> {
+    fn write_multiple_coils(
+        &mut self,
+        range: AddressRange,
+        _iter: &BitIterator,
+    ) -> Result<(), ExceptionCode> {
         log::info!("write multiple coils {:?}", range);
         Ok(())
     }
 
-    fn write_multiple_registers(&mut self, range: AddressRange, _iter: &RegisterIterator) -> Result<(), ExceptionCode> {
+    fn write_multiple_registers(
+        &mut self,
+        range: AddressRange,
+        _iter: &RegisterIterator,
+    ) -> Result<(), ExceptionCode> {
         log::info!("write multiple registers {:?}", range);
         Ok(())
     }

--- a/rodbus/examples/server.rs
+++ b/rodbus/examples/server.rs
@@ -51,12 +51,24 @@ impl ServerHandler for SimpleHandler {
         Self::get_range_of(self.input_registers.as_slice(), range)
     }
 
-    fn write_single_coil(&mut self, _: Indexed<bool>) -> Result<(), ExceptionCode> {
-        Err(ExceptionCode::IllegalFunction)
+    fn write_single_coil(&mut self, value: Indexed<bool>) -> Result<(), ExceptionCode> {
+        log::info!("write single coil, index: {} value: {}", value.index, value. value);
+        Ok(())
     }
 
-    fn write_single_register(&mut self, _: Indexed<u16>) -> Result<(), ExceptionCode> {
-        Err(ExceptionCode::IllegalFunction)
+    fn write_single_register(&mut self, value: Indexed<u16>) -> Result<(), ExceptionCode> {
+        log::info!("write single register, index: {} value: {}", value.index, value.value);
+        Ok(())
+    }
+
+    fn write_multiple_coils(&mut self, range: AddressRange, _iter: &BitIterator) -> Result<(), ExceptionCode> {
+        log::info!("write multiple coils {:?}", range);
+        Ok(())
+    }
+
+    fn write_multiple_registers(&mut self, range: AddressRange, _iter: &RegisterIterator) -> Result<(), ExceptionCode> {
+        log::info!("write multiple registers {:?}", range);
+        Ok(())
     }
 }
 

--- a/rodbus/src/error.rs
+++ b/rodbus/src/error.rs
@@ -94,6 +94,10 @@ pub mod details {
         BadSeekOperation,
         /// Byte count would exceed maximum allowed size in the ADU of u8
         BadByteCount(usize),
+        /// BitIterator with bad arguments
+        BadBitIteratorArgs,
+        /// RegisterIterator with bad arguments
+        BadRegisterIteratorArgs,
     }
 
     impl std::error::Error for InternalError {}
@@ -129,6 +133,12 @@ pub mod details {
                     "Byte count of in ADU {} exceeds maximum size of u8",
                     size
                 ),
+                InternalError::BadBitIteratorArgs => {
+                    f.write_str("Bit iterator created with bad arguments")
+                }
+                InternalError::BadRegisterIteratorArgs => {
+                    f.write_str("Register iterator created with bad arguments")
+                }
             }
         }
     }

--- a/rodbus/src/server/handler.rs
+++ b/rodbus/src/server/handler.rs
@@ -48,12 +48,20 @@ pub trait ServerHandler: Send + 'static {
     }
 
     /// Write multiple coils
-    fn write_multiple_coils(&mut self, _range: AddressRange, _iter: &BitIterator) -> Result<(), ExceptionCode> {
+    fn write_multiple_coils(
+        &mut self,
+        _range: AddressRange,
+        _iter: &BitIterator,
+    ) -> Result<(), ExceptionCode> {
         Err(ExceptionCode::IllegalFunction)
     }
 
     /// Write multiple registers
-    fn write_multiple_registers(&mut self, _range: AddressRange, _iter: &RegisterIterator) -> Result<(), ExceptionCode> {
+    fn write_multiple_registers(
+        &mut self,
+        _range: AddressRange,
+        _iter: &RegisterIterator,
+    ) -> Result<(), ExceptionCode> {
         Err(ExceptionCode::IllegalFunction)
     }
 

--- a/rodbus/src/server/handler.rs
+++ b/rodbus/src/server/handler.rs
@@ -18,22 +18,44 @@ pub trait ServerHandler: Send + 'static {
     }
 
     /// Read a range of coils, returning the matching slice of bool or an exception
-    fn read_coils(&mut self, range: AddressRange) -> Result<&[bool], ExceptionCode>;
+    fn read_coils(&mut self, _: AddressRange) -> Result<&[bool], ExceptionCode> {
+        Err(ExceptionCode::IllegalFunction)
+    }
 
     /// Read a range of discrete inputs, returning the matching slice of bool or an exception
-    fn read_discrete_inputs(&mut self, range: AddressRange) -> Result<&[bool], ExceptionCode>;
+    fn read_discrete_inputs(&mut self, _range: AddressRange) -> Result<&[bool], ExceptionCode> {
+        Err(ExceptionCode::IllegalFunction)
+    }
 
     /// Read a range of holding registers, returning the matching slice of u16 or an exception
-    fn read_holding_registers(&mut self, range: AddressRange) -> Result<&[u16], ExceptionCode>;
+    fn read_holding_registers(&mut self, _range: AddressRange) -> Result<&[u16], ExceptionCode> {
+        Err(ExceptionCode::IllegalFunction)
+    }
 
     /// Read a range of input registers, returning the matching slice of u16 or an exception
-    fn read_input_registers(&mut self, range: AddressRange) -> Result<&[u16], ExceptionCode>;
+    fn read_input_registers(&mut self, _range: AddressRange) -> Result<&[u16], ExceptionCode> {
+        Err(ExceptionCode::IllegalFunction)
+    }
 
     /// Write a single coil value
-    fn write_single_coil(&mut self, value: Indexed<bool>) -> Result<(), ExceptionCode>;
+    fn write_single_coil(&mut self, _value: Indexed<bool>) -> Result<(), ExceptionCode> {
+        Err(ExceptionCode::IllegalFunction)
+    }
 
     /// Write a single coil value
-    fn write_single_register(&mut self, value: Indexed<u16>) -> Result<(), ExceptionCode>;
+    fn write_single_register(&mut self, _value: Indexed<u16>) -> Result<(), ExceptionCode> {
+        Err(ExceptionCode::IllegalFunction)
+    }
+
+    /// Write multiple coils
+    fn write_multiple_coils(&mut self, _range: AddressRange, _iter: &BitIterator) -> Result<(), ExceptionCode> {
+        Err(ExceptionCode::IllegalFunction)
+    }
+
+    /// Write multiple registers
+    fn write_multiple_registers(&mut self, _range: AddressRange, _iter: &RegisterIterator) -> Result<(), ExceptionCode> {
+        Err(ExceptionCode::IllegalFunction)
+    }
 
     /// retrieve a sub-range of a slice or ExceptionCode::IllegalDataAddress
     fn get_range_of<T>(slice: &[T], range: AddressRange) -> Result<&[T], ExceptionCode> {

--- a/rodbus/src/server/task.rs
+++ b/rodbus/src/server/task.rs
@@ -168,7 +168,7 @@ where
             None => {
                 warn!(
                     "received frame for unmapped unit id: {}",
-                    frame.header.unit_id.to_u8()
+                    frame.header.unit_id.value
                 );
                 return Ok(());
             }

--- a/rodbus/src/server/task.rs
+++ b/rodbus/src/server/task.rs
@@ -12,12 +12,12 @@ use crate::error::details::ExceptionCode;
 use crate::error::*;
 use crate::server::handler::{ServerHandler, ServerHandlerMap};
 use crate::service::function::{FunctionCode, ADU};
+use crate::service::parse::{parse_write_multiple_coils, parse_write_multiple_registers};
 use crate::service::traits::ParseRequest;
 use crate::tcp::frame::{MBAPFormatter, MBAPParser};
 use crate::types::{AddressRange, Indexed};
 use crate::util::cursor::ReadCursor;
 use crate::util::frame::{Frame, FrameFormatter, FrameHeader, FramedReader};
-use crate::service::parse::{parse_write_multiple_coils, parse_write_multiple_registers};
 
 struct SessionTracker {
     max: usize,
@@ -310,12 +310,9 @@ where
                     Err(ex) => self
                         .writer
                         .format(frame.header, &ADU::new(function.as_error(), &ex))?,
-                    Ok(()) => {
-                        self.writer.format(
-                            frame.header,
-                            &ADU::new(function.get_value(), &value),
-                        )?
-                    }
+                    Ok(()) => self
+                        .writer
+                        .format(frame.header, &ADU::new(function.get_value(), &value))?,
                 },
             },
             FunctionCode::WriteSingleRegister => match Indexed::<u16>::parse(&mut cursor) {
@@ -330,12 +327,9 @@ where
                     Err(ex) => self
                         .writer
                         .format(frame.header, &ADU::new(function.as_error(), &ex))?,
-                    Ok(()) => {
-                        self.writer.format(
-                            frame.header,
-                            &ADU::new(function.get_value(), &value),
-                        )?
-                    }
+                    Ok(()) => self
+                        .writer
+                        .format(frame.header, &ADU::new(function.get_value(), &value))?,
                 },
             },
             FunctionCode::WriteMultipleCoils => match parse_write_multiple_coils(&mut cursor) {
@@ -346,37 +340,39 @@ where
                         &ADU::new(function.as_error(), &ExceptionCode::IllegalDataValue),
                     )?
                 }
-                Ok((range, iterator)) => match handler.lock().await.write_multiple_coils(range, &iterator) {
-                    Err(ex) => self
-                        .writer
-                        .format(frame.header, &ADU::new(function.as_error(), &ex))?,
-                    Ok(()) => {
-                        self.writer.format(
-                            frame.header,
-                            &ADU::new(function.get_value(), &range),
-                        )?
+                Ok((range, iterator)) => {
+                    match handler.lock().await.write_multiple_coils(range, &iterator) {
+                        Err(ex) => self
+                            .writer
+                            .format(frame.header, &ADU::new(function.as_error(), &ex))?,
+                        Ok(()) => self
+                            .writer
+                            .format(frame.header, &ADU::new(function.get_value(), &range))?,
                     }
-                },
-            },
-            FunctionCode::WriteMultipleRegisters => match parse_write_multiple_registers(&mut cursor) {
-                Err(e) => {
-                    warn!("error parsing {:?} request: {}", function, e);
-                    self.writer.format(
-                        frame.header,
-                        &ADU::new(function.as_error(), &ExceptionCode::IllegalDataValue),
-                    )?
                 }
-                Ok((range, iterator)) => match handler.lock().await.write_multiple_registers(range, &iterator) {
-                    Err(ex) => self
-                        .writer
-                        .format(frame.header, &ADU::new(function.as_error(), &ex))?,
-                    Ok(()) => {
+            },
+            FunctionCode::WriteMultipleRegisters => {
+                match parse_write_multiple_registers(&mut cursor) {
+                    Err(e) => {
+                        warn!("error parsing {:?} request: {}", function, e);
                         self.writer.format(
                             frame.header,
-                            &ADU::new(function.get_value(), &range),
+                            &ADU::new(function.as_error(), &ExceptionCode::IllegalDataValue),
                         )?
                     }
-                },
+                    Ok((range, iterator)) => match handler
+                        .lock()
+                        .await
+                        .write_multiple_registers(range, &iterator)
+                    {
+                        Err(ex) => self
+                            .writer
+                            .format(frame.header, &ADU::new(function.as_error(), &ex))?,
+                        Ok(()) => self
+                            .writer
+                            .format(frame.header, &ADU::new(function.get_value(), &range))?,
+                    },
+                }
             }
         };
 

--- a/rodbus/src/service/mod.rs
+++ b/rodbus/src/service/mod.rs
@@ -1,5 +1,6 @@
 pub(crate) mod function;
 mod impls;
+pub(crate) mod parse;
 mod serialization;
 pub(crate) mod services;
 pub(crate) mod traits;

--- a/rodbus/src/service/parse.rs
+++ b/rodbus/src/service/parse.rs
@@ -1,0 +1,28 @@
+use crate::util::cursor::ReadCursor;
+use crate::types::{AddressRange, BitIterator, RegisterIterator};
+use crate::error::Error;
+use crate::error::details::ADUParseError;
+use crate::service::traits::ParseRequest;
+
+pub fn parse_write_multiple_coils<'a>(cursor: &mut ReadCursor<'a>) -> Result<(AddressRange, BitIterator<'a>), Error> {
+    let range = AddressRange::parse(cursor)?;
+    let byte_count = cursor.read_u8()? as usize;
+    let expected = crate::util::bits::num_bytes_for_bits(range.count);
+    if byte_count != expected {
+        return Err(ADUParseError::RequestByteCountMismatch(expected, byte_count).into());
+    }
+    let iterator = BitIterator::create(cursor.read_bytes(byte_count)?, range)?;
+    Ok((range, iterator))
+}
+
+pub fn parse_write_multiple_registers<'a>(cursor: &mut ReadCursor<'a>) -> Result<(AddressRange, RegisterIterator<'a>), Error> {
+    let range = AddressRange::parse(cursor)?;
+    let byte_count = cursor.read_u8()? as usize;
+    let expected = 2 * (range.count as usize);
+    if byte_count != expected {
+        return Err(ADUParseError::RequestByteCountMismatch(expected, byte_count).into());
+    }
+
+    let iterator = RegisterIterator::create(cursor.read_bytes(byte_count)?, range)?;
+    Ok((range, iterator))
+}

--- a/rodbus/src/service/parse.rs
+++ b/rodbus/src/service/parse.rs
@@ -1,10 +1,12 @@
-use crate::util::cursor::ReadCursor;
-use crate::types::{AddressRange, BitIterator, RegisterIterator};
-use crate::error::Error;
 use crate::error::details::ADUParseError;
+use crate::error::Error;
 use crate::service::traits::ParseRequest;
+use crate::types::{AddressRange, BitIterator, RegisterIterator};
+use crate::util::cursor::ReadCursor;
 
-pub fn parse_write_multiple_coils<'a>(cursor: &mut ReadCursor<'a>) -> Result<(AddressRange, BitIterator<'a>), Error> {
+pub fn parse_write_multiple_coils<'a>(
+    cursor: &mut ReadCursor<'a>,
+) -> Result<(AddressRange, BitIterator<'a>), Error> {
     let range = AddressRange::parse(cursor)?;
     let byte_count = cursor.read_u8()? as usize;
     let expected = crate::util::bits::num_bytes_for_bits(range.count);
@@ -15,7 +17,9 @@ pub fn parse_write_multiple_coils<'a>(cursor: &mut ReadCursor<'a>) -> Result<(Ad
     Ok((range, iterator))
 }
 
-pub fn parse_write_multiple_registers<'a>(cursor: &mut ReadCursor<'a>) -> Result<(AddressRange, RegisterIterator<'a>), Error> {
+pub fn parse_write_multiple_registers<'a>(
+    cursor: &mut ReadCursor<'a>,
+) -> Result<(AddressRange, RegisterIterator<'a>), Error> {
     let range = AddressRange::parse(cursor)?;
     let byte_count = cursor.read_u8()? as usize;
     let expected = 2 * (range.count as usize);

--- a/rodbus/src/service/serialization/client_request_parsers.rs
+++ b/rodbus/src/service/serialization/client_request_parsers.rs
@@ -1,15 +1,13 @@
-use crate::error::details::ADUParseError;
 use crate::error::*;
 use crate::service::traits::ParseRequest;
 use crate::types::{coil_from_u16, AddressRange, Indexed, WriteMultiple};
 use crate::util::cursor::ReadCursor;
+use crate::service::parse::{parse_write_multiple_coils, parse_write_multiple_registers};
 
 impl ParseRequest for AddressRange {
     fn parse(cursor: &mut ReadCursor) -> Result<Self, Error> {
-        Ok(AddressRange::new(
-            cursor.read_u16_be()?,
-            cursor.read_u16_be()?,
-        ))
+        let range = AddressRange::new(cursor.read_u16_be()?,  cursor.read_u16_be()?);
+        Ok(range)
     }
 }
 
@@ -30,62 +28,19 @@ impl ParseRequest for Indexed<u16> {
 
 impl ParseRequest for WriteMultiple<bool> {
     fn parse(cursor: &mut ReadCursor) -> Result<Self, Error> {
-        let range = AddressRange::parse(cursor)?;
-        let byte_count = cursor.read_u8()? as usize;
-        let expected = crate::util::bits::num_bytes_for_bits(range.count);
-        if byte_count != expected {
-            return Err(ADUParseError::RequestByteCountMismatch(expected, byte_count).into());
-        }
-
-        let mut values = Vec::<bool>::with_capacity(range.count as usize);
-
-        let bytes = cursor.read_bytes(byte_count)?;
-
-        let mut count = 0;
-
-        for byte in bytes {
-            for i in 0..8 {
-                // return early if we hit the count before the end of the byte
-                if count == range.count {
-                    return Ok(WriteMultiple::new(range.start, values));
-                }
-
-                // low order bits first
-                let value = (byte & (1u8 << i)) != 0;
-                values.push(value);
-                count += 1;
-            }
-        }
-
-        Ok(WriteMultiple::new(range.start, values))
+        let (range, iterator) = parse_write_multiple_coils(cursor)?;
+        Ok(WriteMultiple::new(range.start, iterator.collect()))
     }
 }
 
 impl ParseRequest for WriteMultiple<u16> {
     fn parse(cursor: &mut ReadCursor) -> Result<Self, Error> {
-        let range = AddressRange::parse(cursor)?;
-
-        let byte_count = cursor.read_u8()? as usize;
-        let expected = 2 * (range.count as usize);
-
-        if byte_count != expected {
-            return Err(ADUParseError::RequestByteCountMismatch(expected, byte_count).into());
-        }
-
-        if byte_count < cursor.len() {
-            return Err(details::ADUParseError::InsufficientBytesForByteCount(
-                byte_count,
-                cursor.len(),
-            )
-            .into());
-        }
-
-        let mut values = Vec::<u16>::with_capacity(range.count as usize);
-
-        while !cursor.is_empty() {
-            values.push(cursor.read_u16_be()?)
-        }
-
-        Ok(WriteMultiple::new(range.start, values))
+        let (range, iterator) = parse_write_multiple_registers(cursor)?;
+        Ok(WriteMultiple::new(range.start, iterator.collect()))
     }
 }
+
+
+
+
+

--- a/rodbus/src/service/serialization/client_request_parsers.rs
+++ b/rodbus/src/service/serialization/client_request_parsers.rs
@@ -1,12 +1,12 @@
 use crate::error::*;
+use crate::service::parse::{parse_write_multiple_coils, parse_write_multiple_registers};
 use crate::service::traits::ParseRequest;
 use crate::types::{coil_from_u16, AddressRange, Indexed, WriteMultiple};
 use crate::util::cursor::ReadCursor;
-use crate::service::parse::{parse_write_multiple_coils, parse_write_multiple_registers};
 
 impl ParseRequest for AddressRange {
     fn parse(cursor: &mut ReadCursor) -> Result<Self, Error> {
-        let range = AddressRange::new(cursor.read_u16_be()?,  cursor.read_u16_be()?);
+        let range = AddressRange::new(cursor.read_u16_be()?, cursor.read_u16_be()?);
         Ok(range)
     }
 }
@@ -39,8 +39,3 @@ impl ParseRequest for WriteMultiple<u16> {
         Ok(WriteMultiple::new(range.start, iterator.collect()))
     }
 }
-
-
-
-
-

--- a/rodbus/src/tcp/frame.rs
+++ b/rodbus/src/tcp/frame.rs
@@ -122,7 +122,7 @@ impl FrameFormatter for MBAPFormatter {
         cursor.write_u16_be(header.tx_id.to_u16())?;
         cursor.write_u16_be(0)?;
         cursor.seek_from_current(2)?; // write the length later
-        cursor.write_u8(header.unit_id.to_u8())?;
+        cursor.write_u8(header.unit_id.value)?;
 
         let adu_length: usize = {
             let start = cursor.position();

--- a/rodbus/src/types.rs
+++ b/rodbus/src/types.rs
@@ -5,20 +5,25 @@ use crate::error::details::{ADUParseError, InvalidRequest};
 /// Modbus unit identifier, just a type-safe wrapper around u8
 #[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Ord, Eq)]
 pub struct UnitId {
-    id: u8,
+    /// underlying raw value
+    pub value: u8,
 }
 
 /// Start & count tuple used when making various requests
 #[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Ord, Eq)]
 pub struct AddressRange {
+    /// starting address of the range
     pub start: u16,
+    /// count of elements in the range
     pub count: u16,
 }
 
 /// Value and its address
 #[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Ord, Eq)]
 pub struct Indexed<T> {
+    /// address of the value
     pub index: u16,
+    /// associated value
     pub value: T,
 }
 
@@ -36,7 +41,9 @@ where
 /// Used when making write multiple coil/register requests
 #[derive(Debug, Clone)]
 pub struct WriteMultiple<T> {
+    /// starting address
     pub start: u16,
+    /// vector of values
     pub values: Vec<T>,
 }
 
@@ -109,16 +116,8 @@ impl<T> Indexed<T> {
 }
 
 impl UnitId {
-    pub fn new(unit_id: u8) -> Self {
-        Self { id: unit_id }
-    }
-
-    pub fn default() -> Self {
-        Self { id: 0xFF }
-    }
-
-    pub fn to_u8(self) -> u8 {
-        self.id
+    pub fn new(value: u8) -> Self {
+        Self { value }
     }
 }
 

--- a/rodbus/src/types.rs
+++ b/rodbus/src/types.rs
@@ -1,6 +1,6 @@
 use std::convert::TryFrom;
 
-use crate::error::details::{ADUParseError, InvalidRequest};
+use crate::error::details::{ADUParseError, InternalError, InvalidRequest};
 
 /// Modbus unit identifier, just a type-safe wrapper around u8
 #[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Ord, Eq)]
@@ -25,6 +25,111 @@ pub struct Indexed<T> {
     pub index: u16,
     /// associated value
     pub value: T,
+}
+
+/// zero-copy type used to iterate over a collection of bits without allocating
+#[derive(Copy, Clone)]
+pub struct BitIterator<'a> {
+    bytes: &'a [u8],
+    range: AddressRange,
+    pos: u16,
+}
+
+/// zero-copy type used to iterate over a collection of registers without allocating
+#[derive(Copy, Clone)]
+pub struct RegisterIterator<'a> {
+    bytes: &'a [u8],
+    range: AddressRange,
+    pos: u16,
+}
+
+impl<'a> BitIterator<'a> {
+    pub(crate) fn create(
+        bytes: &'a [u8],
+        range: AddressRange,
+    ) -> Result<Self, crate::error::details::InternalError> {
+        if bytes.len() < crate::util::bits::num_bytes_for_bits(range.count) as usize {
+            return Err(InternalError::BadBitIteratorArgs);
+        }
+
+        if range.validate().is_err() {
+            return Err(InternalError::BadBitIteratorArgs);
+        }
+
+        Ok(Self {
+            bytes,
+            range,
+            pos: 0,
+        })
+    }
+}
+
+impl<'a> RegisterIterator<'a> {
+    pub(crate) fn create(
+        bytes: &'a [u8],
+        range: AddressRange,
+    ) -> Result<Self, crate::error::details::InternalError> {
+        let required_bytes = 2 * (range.count as usize);
+
+        if bytes.len() != required_bytes {
+            return Err(InternalError::BadRegisterIteratorArgs);
+        }
+
+        if range.validate().is_err() {
+            return Err(InternalError::BadRegisterIteratorArgs);
+        }
+
+        Ok(Self {
+            bytes,
+            range,
+            pos: 0,
+        })
+    }
+}
+
+impl<'a> Iterator for BitIterator<'a> {
+    type Item = bool;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.pos == self.range.count {
+            return None;
+        }
+        let byte = self.pos / 8;
+        let bit = (self.pos % 8) as u8;
+
+        let value = (self.bytes[byte as usize] & (1 << bit)) != 0;
+        self.pos += 1;
+        Some(value)
+    }
+
+    // implementing this allows collect to optimize the vector capacity
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let remaining = (self.range.count - self.pos) as usize;
+        (remaining, Some(remaining))
+    }
+}
+
+impl<'a> Iterator for RegisterIterator<'a> {
+    type Item = u16;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.pos == self.range.count {
+            return None;
+        }
+
+        let pos = 2 * (self.pos as usize);
+        let high = self.bytes[pos];
+        let low = self.bytes[pos + 1];
+        let value = ((high as u16) << 8) | low as u16;
+        self.pos += 1;
+        Some(value)
+    }
+
+    // implementing this allows collect to optimize the vector capacity
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let remaining = (self.range.count - self.pos) as usize;
+        (remaining, Some(remaining))
+    }
 }
 
 impl<T> std::convert::From<(u16, T)> for Indexed<T>
@@ -123,7 +228,7 @@ impl UnitId {
 
 #[cfg(test)]
 mod tests {
-    use crate::error::details::InvalidRequest;
+    use crate::error::details::*;
 
     use super::*;
 
@@ -154,5 +259,74 @@ mod tests {
                 2
             )))
         );
+    }
+
+    #[test]
+    fn cannot_create_bit_iterator_with_bad_count() {
+        assert_eq!(
+            BitIterator::create(&[], AddressRange::new(0, 1))
+                .err()
+                .unwrap(),
+            InternalError::BadBitIteratorArgs
+        );
+        assert_eq!(
+            BitIterator::create(&[0xFF], AddressRange::new(0, 9))
+                .err()
+                .unwrap(),
+            InternalError::BadBitIteratorArgs
+        );
+    }
+
+    #[test]
+    fn cannot_create_bit_iterator_with_invalid_address_range() {
+        assert_eq!(
+            BitIterator::create(&[0xFF], AddressRange::new(0xFFFF, 7))
+                .err()
+                .unwrap(),
+            InternalError::BadBitIteratorArgs
+        );
+    }
+
+    #[test]
+    fn correctly_iterates_over_low_order_bits() {
+        let iterator = BitIterator::create(&[0x03], AddressRange::new(1, 3)).unwrap();
+        assert_eq!(iterator.size_hint(), (3, Some(3)));
+        let values: Vec<bool> = iterator.collect();
+        assert_eq!(values, vec![true, true, false]);
+    }
+
+    #[test]
+    fn cannot_create_register_iterator_with_invalid_byte_count() {
+        assert_eq!(
+            RegisterIterator::create(&[], AddressRange::new(0, 1))
+                .err()
+                .unwrap(),
+            InternalError::BadRegisterIteratorArgs
+        );
+        assert_eq!(
+            RegisterIterator::create(&[0xFF, 0xFF, 0xFF], AddressRange::new(0, 2))
+                .err()
+                .unwrap(),
+            InternalError::BadRegisterIteratorArgs
+        );
+    }
+
+    #[test]
+    fn cannot_create_register_iterator_with_invalid_address_range() {
+        assert_eq!(
+            RegisterIterator::create(&[0xFF], AddressRange::new(0xFFFF, 7))
+                .err()
+                .unwrap(),
+            InternalError::BadRegisterIteratorArgs
+        );
+    }
+
+    #[test]
+    fn correctly_iterates_over_registers() {
+        let iterator =
+            RegisterIterator::create(&[0xFF, 0xFF, 0x01, 0xCC], AddressRange::new(1, 2)).unwrap();
+        assert_eq!(iterator.size_hint(), (2, Some(2)));
+        let values: Vec<u16> = iterator.collect();
+        assert_eq!(values, vec![0xFFFF, 0x01CC]);
     }
 }


### PR DESCRIPTION
Implements all write functions on the server. Write multiple coils/registers use Bit/Register iterator types that don't allocate, but instead iterate over the underlying request buffer.

Also made `ServerHandler` provide default implementations so that users only have to implement the functions they support.