### PR TITLE
Feature/generic tasks

### DIFF
--- a/rodbus/examples/server.rs
+++ b/rodbus/examples/server.rs
@@ -1,8 +1,9 @@
 use std::net::SocketAddr;
 use std::str::FromStr;
 
-use rodbus::prelude::*;
 use tokio::net::TcpListener;
+
+use rodbus::prelude::*;
 
 struct SimpleHandler {
     coils: Vec<bool>,

--- a/rodbus/src/client/channel.rs
+++ b/rodbus/src/client/channel.rs
@@ -5,7 +5,7 @@ use tokio::sync::mpsc;
 
 use crate::client::message::Request;
 use crate::client::session::AsyncSession;
-use crate::client::task::ChannelTask;
+use crate::tcp::client::TcpChannelTask;
 use crate::types::UnitId;
 
 /// Channel from which `AsyncSession` objects can be created to make requests
@@ -85,7 +85,7 @@ impl Channel {
         connect_retry: Box<dyn ReconnectStrategy + Send>,
     ) -> (Self, impl std::future::Future<Output = ()>) {
         let (tx, rx) = mpsc::channel(max_queued_requests);
-        let task = async move { ChannelTask::new(addr, rx, connect_retry).run().await };
+        let task = async move { TcpChannelTask::new(addr, rx, connect_retry).run().await };
         (Channel { tx }, task)
     }
 

--- a/rodbus/src/client/task.rs
+++ b/rodbus/src/client/task.rs
@@ -1,11 +1,8 @@
-use std::net::SocketAddr;
 use std::time::Duration;
 
-use log::{info, warn};
 use tokio::prelude::*;
 use tokio::sync::*;
 
-use crate::client::channel::ReconnectStrategy;
 use crate::client::message::{Request, ServiceRequest};
 use crate::error::*;
 use crate::service::function::ADU;
@@ -18,7 +15,7 @@ use crate::util::frame::{FrameFormatter, FrameHeader, FramedReader, TxId};
 /**
 * We always service requests in a TCP session until one of the following occurs
 */
-enum SessionError {
+pub(crate) enum SessionError {
     // the stream errors or there is an unrecoverable framing issue
     IOError,
     // the mpsc is closed (dropped)  on the sender side
@@ -34,62 +31,24 @@ impl SessionError {
     }
 }
 
-/// Channel loop
-///
-/// This loop handles the request one by one. It serializes the request
-/// and sends it through the socket. It then waits for a response, deserialize
-/// it and sends it back to the oneshot provided by the caller.
-pub struct ChannelTask {
-    addr: SocketAddr,
+pub(crate) struct ClientLoop {
     rx: mpsc::Receiver<Request>,
-    connect_retry: Box<dyn ReconnectStrategy + Send>,
     formatter: MBAPFormatter,
     reader: FramedReader<MBAPParser>,
     tx_id: TxId,
 }
 
-impl ChannelTask {
-    pub fn new(
-        addr: SocketAddr,
-        rx: mpsc::Receiver<Request>,
-        connect_retry: Box<dyn ReconnectStrategy + Send>,
-    ) -> Self {
+impl ClientLoop {
+    pub fn new(rx: mpsc::Receiver<Request>) -> Self {
         Self {
-            addr,
             rx,
             formatter: MBAPFormatter::new(),
-            connect_retry,
             reader: FramedReader::new(MBAPParser::new()),
             tx_id: TxId::default(),
         }
     }
 
-    pub async fn run(&mut self) {
-        // try to connect
-        loop {
-            match tokio::net::TcpStream::connect(self.addr).await {
-                Err(e) => {
-                    warn!("error connecting: {}", e);
-                    let delay = self.connect_retry.next_delay();
-                    if self.fail_requests_for(delay).await.is_err() {
-                        // this occurs when the mpsc is dropped, so the task can exit
-                        return;
-                    }
-                }
-                Ok(stream) => {
-                    info!("connected to: {}", self.addr);
-                    match self.run_session(stream).await {
-                        // the mpsc was closed, end the task
-                        SessionError::Shutdown => return,
-                        // re-establish the connection
-                        SessionError::IOError => {}
-                    }
-                }
-            }
-        }
-    }
-
-    async fn run_session<T>(&mut self, mut io: T) -> SessionError
+    pub async fn run<T>(&mut self, mut io: T) -> SessionError
     where
         T: AsyncRead + AsyncWrite + Unpin,
     {
@@ -233,7 +192,7 @@ impl ChannelTask {
         }
     }
 
-    async fn fail_requests_for(&mut self, duration: Duration) -> Result<(), ()> {
+    pub async fn fail_requests_for(&mut self, duration: Duration) -> Result<(), ()> {
         let deadline = tokio::time::Instant::now() + duration;
 
         loop {

--- a/rodbus/src/server/mod.rs
+++ b/rodbus/src/server/mod.rs
@@ -1,10 +1,10 @@
 use tokio::net::TcpListener;
 
 use crate::server::handler::{ServerHandler, ServerHandlerMap};
-use crate::server::task::ServerTask;
+use crate::tcp::server::ServerTask;
 
 pub mod handler;
-mod task;
+pub(crate) mod task;
 pub(crate) mod validator;
 
 /// Spawns a TCP server task onto the runtime. This method can only

--- a/rodbus/src/server/task.rs
+++ b/rodbus/src/server/task.rs
@@ -1,12 +1,6 @@
-use std::collections::BTreeMap;
-use std::sync::Arc;
-
 use futures::future::FutureExt;
 use futures::select;
-use log::{info, warn};
 use tokio::io::{AsyncRead, AsyncWrite, AsyncWriteExt};
-use tokio::net::TcpListener;
-use tokio::sync::Mutex;
 
 use crate::error::details::ExceptionCode;
 use crate::error::*;
@@ -20,93 +14,7 @@ use crate::types::{AddressRange, Indexed};
 use crate::util::cursor::ReadCursor;
 use crate::util::frame::{Frame, FrameFormatter, FrameHeader, FramedReader};
 
-struct SessionTracker {
-    max: usize,
-    id: u64,
-    sessions: BTreeMap<u64, tokio::sync::mpsc::Sender<()>>,
-}
-
-type SessionTrackerWrapper = Arc<Mutex<Box<SessionTracker>>>;
-
-impl SessionTracker {
-    fn new(max: usize) -> SessionTracker {
-        Self {
-            max,
-            id: 0,
-            sessions: BTreeMap::new(),
-        }
-    }
-
-    fn get_next_id(&mut self) -> u64 {
-        let ret = self.id;
-        self.id += 1;
-        ret
-    }
-
-    pub fn wrapped(max: usize) -> SessionTrackerWrapper {
-        Arc::new(Mutex::new(Box::new(Self::new(max))))
-    }
-
-    pub fn add(&mut self, sender: tokio::sync::mpsc::Sender<()>) -> u64 {
-        // TODO - this is so ugly. there's a nightly API on BTreeMap that has a remove_first
-        if !self.sessions.is_empty() && self.sessions.len() >= self.max {
-            let id = *self.sessions.keys().next().unwrap();
-            warn!("exceeded max connections, closing oldest session: {}", id);
-            // when the record drops, and there are no more senders,
-            // the other end will stop the task
-            self.sessions.remove(&id).unwrap();
-        }
-
-        let id = self.get_next_id();
-        self.sessions.insert(id, sender);
-        id
-    }
-
-    pub fn remove(&mut self, id: u64) {
-        self.sessions.remove(&id);
-    }
-}
-
-pub struct ServerTask<T: ServerHandler> {
-    listener: TcpListener,
-    handlers: ServerHandlerMap<T>,
-    tracker: SessionTrackerWrapper,
-}
-
-impl<T> ServerTask<T>
-where
-    T: ServerHandler,
-{
-    pub fn new(max_sessions: usize, listener: TcpListener, handlers: ServerHandlerMap<T>) -> Self {
-        Self {
-            listener,
-            handlers,
-            tracker: SessionTracker::wrapped(max_sessions),
-        }
-    }
-
-    pub async fn run(&mut self) -> std::io::Result<()> {
-        loop {
-            let (socket, addr) = self.listener.accept().await?;
-
-            let handlers = self.handlers.clone();
-            let tracker = self.tracker.clone();
-            let (tx, rx) = tokio::sync::mpsc::channel(1);
-
-            let id = self.tracker.lock().await.add(tx);
-
-            info!("accepted connection {} from: {}", id, addr);
-
-            tokio::spawn(async move {
-                SessionTask::new(socket, handlers, rx).run().await.ok();
-                info!("shutdown session: {}", id);
-                tracker.lock().await.remove(id);
-            });
-        }
-    }
-}
-
-struct SessionTask<T, U>
+pub(crate) struct SessionTask<T, U>
 where
     T: ServerHandler,
     U: AsyncRead + AsyncWrite + Unpin,
@@ -123,7 +31,7 @@ where
     T: ServerHandler,
     U: AsyncRead + AsyncWrite + Unpin,
 {
-    pub fn new(
+    pub(crate) fn new(
         io: U,
         handlers: ServerHandlerMap<T>,
         shutdown: tokio::sync::mpsc::Receiver<()>,
@@ -148,7 +56,7 @@ where
         Ok(())
     }
 
-    async fn run(&mut self) -> std::result::Result<(), Error> {
+    pub(crate) async fn run(&mut self) -> std::result::Result<(), Error> {
         loop {
             self.run_one().await?;
         }
@@ -173,7 +81,7 @@ where
         // if no addresses match, then don't respond
         let handler = match self.handlers.get(frame.header.unit_id) {
             None => {
-                warn!(
+                log::warn!(
                     "received frame for unmapped unit id: {}",
                     frame.header.unit_id.value
                 );
@@ -184,13 +92,13 @@ where
 
         let function = match cursor.read_u8() {
             Err(_) => {
-                warn!("received an empty frame");
+                log::warn!("received an empty frame");
                 return Ok(());
             }
             Ok(value) => match FunctionCode::get(value) {
                 Some(x) => x,
                 None => {
-                    warn!("received unknown function code: {}", value);
+                    log::warn!("received unknown function code: {}", value);
                     return self
                         .reply_with_exception(
                             frame.header,
@@ -209,7 +117,7 @@ where
             match function {
                 FunctionCode::ReadCoils => match AddressRange::parse(&mut cursor) {
                     Err(e) => {
-                        warn!("error parsing {:?} request: {}", function, e);
+                        log::warn!("error parsing {:?} request: {}", function, e);
                         self.writer.format(
                             frame.header,
                             &ADU::new(function.as_error(), &ExceptionCode::IllegalDataValue),
@@ -226,7 +134,7 @@ where
                 },
                 FunctionCode::ReadDiscreteInputs => match AddressRange::parse(&mut cursor) {
                     Err(e) => {
-                        warn!("error parsing {:?} request: {}", function, e);
+                        log::warn!("error parsing {:?} request: {}", function, e);
                         self.writer.format(
                             frame.header,
                             &ADU::new(function.as_error(), &ExceptionCode::IllegalDataValue),
@@ -243,7 +151,7 @@ where
                 },
                 FunctionCode::ReadHoldingRegisters => match AddressRange::parse(&mut cursor) {
                     Err(e) => {
-                        warn!("error parsing {:?} request: {}", function, e);
+                        log::warn!("error parsing {:?} request: {}", function, e);
                         self.writer.format(
                             frame.header,
                             &ADU::new(function.as_error(), &ExceptionCode::IllegalDataValue),
@@ -260,7 +168,7 @@ where
                 },
                 FunctionCode::ReadInputRegisters => match AddressRange::parse(&mut cursor) {
                     Err(e) => {
-                        warn!("error parsing {:?} request: {}", function, e);
+                        log::warn!("error parsing {:?} request: {}", function, e);
                         self.writer.format(
                             frame.header,
                             &ADU::new(function.as_error(), &ExceptionCode::IllegalDataValue),
@@ -277,7 +185,7 @@ where
                 },
                 FunctionCode::WriteSingleCoil => match Indexed::<bool>::parse(&mut cursor) {
                     Err(e) => {
-                        warn!("error parsing {:?} request: {}", function, e);
+                        log::warn!("error parsing {:?} request: {}", function, e);
                         self.writer.format(
                             frame.header,
                             &ADU::new(function.as_error(), &ExceptionCode::IllegalDataValue),
@@ -294,7 +202,7 @@ where
                 },
                 FunctionCode::WriteSingleRegister => match Indexed::<u16>::parse(&mut cursor) {
                     Err(e) => {
-                        warn!("error parsing {:?} request: {}", function, e);
+                        log::warn!("error parsing {:?} request: {}", function, e);
                         self.writer.format(
                             frame.header,
                             &ADU::new(function.as_error(), &ExceptionCode::IllegalDataValue),
@@ -311,7 +219,7 @@ where
                 },
                 FunctionCode::WriteMultipleCoils => match parse_write_multiple_coils(&mut cursor) {
                     Err(e) => {
-                        warn!("error parsing {:?} request: {}", function, e);
+                        log::warn!("error parsing {:?} request: {}", function, e);
                         self.writer.format(
                             frame.header,
                             &ADU::new(function.as_error(), &ExceptionCode::IllegalDataValue),
@@ -329,7 +237,7 @@ where
                 FunctionCode::WriteMultipleRegisters => {
                     match parse_write_multiple_registers(&mut cursor) {
                         Err(e) => {
-                            warn!("error parsing {:?} request: {}", function, e);
+                            log::warn!("error parsing {:?} request: {}", function, e);
                             self.writer.format(
                                 frame.header,
                                 &ADU::new(function.as_error(), &ExceptionCode::IllegalDataValue),

--- a/rodbus/src/service/parse.rs
+++ b/rodbus/src/service/parse.rs
@@ -38,9 +38,9 @@ mod tests {
 
     #[cfg(test)]
     mod coils {
+        use crate::util::cursor::ReadCursor;
 
         use super::super::*;
-        use crate::util::cursor::ReadCursor;
 
         #[test]
         fn fails_when_too_few_bytes_for_coil_byte_count() {
@@ -82,9 +82,9 @@ mod tests {
 
     #[cfg(test)]
     mod registers {
+        use crate::util::cursor::ReadCursor;
 
         use super::super::*;
-        use crate::util::cursor::ReadCursor;
 
         #[test]
         fn fails_when_too_few_bytes_for_coil_byte_count() {

--- a/rodbus/src/tcp/client.rs
+++ b/rodbus/src/tcp/client.rs
@@ -1,0 +1,52 @@
+use std::net::SocketAddr;
+
+use tokio::sync::mpsc::Receiver;
+
+use crate::client::channel::ReconnectStrategy;
+use crate::client::message::Request;
+use crate::client::task::{ClientLoop, SessionError};
+
+pub(crate) struct TcpChannelTask {
+    addr: SocketAddr,
+    connect_retry: Box<dyn ReconnectStrategy + Send>,
+    client_loop: ClientLoop,
+}
+
+impl TcpChannelTask {
+    pub fn new(
+        addr: SocketAddr,
+        rx: Receiver<Request>,
+        connect_retry: Box<dyn ReconnectStrategy + Send>,
+    ) -> Self {
+        Self {
+            addr,
+            connect_retry,
+            client_loop: ClientLoop::new(rx),
+        }
+    }
+
+    pub async fn run(&mut self) {
+        // try to connect
+        loop {
+            match tokio::net::TcpStream::connect(self.addr).await {
+                Err(e) => {
+                    log::warn!("error connecting: {}", e);
+                    let delay = self.connect_retry.next_delay();
+                    if self.client_loop.fail_requests_for(delay).await.is_err() {
+                        // this occurs when the mpsc is dropped, so the task can exit
+                        return;
+                    }
+                }
+                Ok(stream) => {
+                    log::info!("connected to: {}", self.addr);
+                    match self.client_loop.run(stream).await {
+                        // the mpsc was closed, end the task
+                        SessionError::Shutdown => return,
+                        // re-establish the connection
+                        SessionError::IOError => {}
+                    }
+                }
+            }
+        }
+    }
+}

--- a/rodbus/src/tcp/mod.rs
+++ b/rodbus/src/tcp/mod.rs
@@ -1,2 +1,3 @@
 pub(crate) mod client;
 pub(crate) mod frame;
+pub(crate) mod server;

--- a/rodbus/src/tcp/mod.rs
+++ b/rodbus/src/tcp/mod.rs
@@ -1,1 +1,2 @@
+pub(crate) mod client;
 pub(crate) mod frame;

--- a/rodbus/src/tcp/server.rs
+++ b/rodbus/src/tcp/server.rs
@@ -1,0 +1,96 @@
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+use tokio::net::TcpListener;
+use tokio::sync::Mutex;
+
+use crate::server::handler::{ServerHandler, ServerHandlerMap};
+
+struct SessionTracker {
+    max: usize,
+    id: u64,
+    sessions: BTreeMap<u64, tokio::sync::mpsc::Sender<()>>,
+}
+
+type SessionTrackerWrapper = Arc<Mutex<Box<SessionTracker>>>;
+
+impl SessionTracker {
+    fn new(max: usize) -> SessionTracker {
+        Self {
+            max,
+            id: 0,
+            sessions: BTreeMap::new(),
+        }
+    }
+
+    fn get_next_id(&mut self) -> u64 {
+        let ret = self.id;
+        self.id += 1;
+        ret
+    }
+
+    pub fn wrapped(max: usize) -> SessionTrackerWrapper {
+        Arc::new(Mutex::new(Box::new(Self::new(max))))
+    }
+
+    pub fn add(&mut self, sender: tokio::sync::mpsc::Sender<()>) -> u64 {
+        // TODO - this is so ugly. there's a nightly API on BTreeMap that has a remove_first
+        if !self.sessions.is_empty() && self.sessions.len() >= self.max {
+            let id = *self.sessions.keys().next().unwrap();
+            log::warn!("exceeded max connections, closing oldest session: {}", id);
+            // when the record drops, and there are no more senders,
+            // the other end will stop the task
+            self.sessions.remove(&id).unwrap();
+        }
+
+        let id = self.get_next_id();
+        self.sessions.insert(id, sender);
+        id
+    }
+
+    pub fn remove(&mut self, id: u64) {
+        self.sessions.remove(&id);
+    }
+}
+
+pub struct ServerTask<T: ServerHandler> {
+    listener: TcpListener,
+    handlers: ServerHandlerMap<T>,
+    tracker: SessionTrackerWrapper,
+}
+
+impl<T> ServerTask<T>
+where
+    T: ServerHandler,
+{
+    pub fn new(max_sessions: usize, listener: TcpListener, handlers: ServerHandlerMap<T>) -> Self {
+        Self {
+            listener,
+            handlers,
+            tracker: SessionTracker::wrapped(max_sessions),
+        }
+    }
+
+    pub async fn run(&mut self) -> std::io::Result<()> {
+        loop {
+            let (socket, addr) = self.listener.accept().await?;
+
+            let handlers = self.handlers.clone();
+            let tracker = self.tracker.clone();
+            let (tx, rx) = tokio::sync::mpsc::channel(1);
+
+            let id = self.tracker.lock().await.add(tx);
+
+            log::info!("accepted connection {} from: {}", id, addr);
+
+            tokio::spawn(async move {
+                crate::server::task::SessionTask::new(socket, handlers, rx)
+                    .run()
+                    .await
+                    .ok();
+                log::info!("shutdown session: {}", id);
+                tracker.lock().await.remove(id);
+            });
+        }
+    }
+}


### PR DESCRIPTION
separate the TCP specific parts of the client/server from the parts that can just be generically parameterized using the trait bounds `AsyncRead + AsyncWrite + Unpin`.  This will make implementing serial and TLS quite easy.

It also should make the generic pieces testable using tokio_test::io::Mock.